### PR TITLE
starting ssh-agent before ssh-adding

### DIFF
--- a/electro
+++ b/electro
@@ -162,6 +162,7 @@ start_services() {
 
     check_vpn
 
+    eval "$(ssh-agent)"
     check_os=$(uname -s)
     if [[ ${check_os} == "Darwin" ]]; then
         ssh-add -K ~/.ssh/id_rsa


### PR DESCRIPTION
PR to address issue #4 (ssh-agent might not be initialised when ssh-adding, thus exiting the script)